### PR TITLE
Properly include logo and background

### DIFF
--- a/make_innertheme.sh
+++ b/make_innertheme.sh
@@ -8,7 +8,7 @@ echo "
 \def\insertbackgroundimg{%
 \resizebox{1.05\paperwidth}{1.05\paperheight}{
 " >> beamerinnerthemeAAU.sty
-svg2tikz assets/background.svg | sed -n '/tikzpicture/,/tikzpicture/p' | sed -e 's/c29224e/aau@blue1/g' >> beamerinnerthemeAAU.sty
+svg2tikz assets/background.svg | sed -n '/tikzpicture/,/tikzpicture/p' | sed -e 's/c29224e/aau@blue1/g' | sed -e 's/\\globalscale/1/g' >> beamerinnerthemeAAU.sty
 echo "}}" >> beamerinnerthemeAAU.sty
 
 
@@ -18,5 +18,5 @@ echo "
 \definecolor{cffffff}{RGB}{255,255,255}
 \resizebox{\graphicswidth}{!} {%
 " >> beamerinnerthemeAAU.sty
-svg2tikz assets/logo.svg | sed -n '/tikzpicture/,/tikzpicture/p' >> beamerinnerthemeAAU.sty
+svg2tikz assets/logo.svg | sed -n '/tikzpicture/,/tikzpicture/p' | sed -e 's/\\globalscale/1/g' >> beamerinnerthemeAAU.sty
 echo "}}" >> beamerinnerthemeAAU.sty


### PR DESCRIPTION
With the implementation of `https://github.com/xyz2tex/svg2tikz/pull/71` it should now be possible to include the logo and background in the AAU-beamer-template.
The svg2tikz tool still has some quirks in terms of using globalscale which generally does not seem to play nice with texlive. For this reason we replace the `\globalscale` directive with a `1` as this is what globalscale seems to expand to anyways.

